### PR TITLE
Make compilation succeed under stricter compile flags

### DIFF
--- a/include/sltbench/impl/StaticAssertsUtil.h
+++ b/include/sltbench/impl/StaticAssertsUtil.h
@@ -14,7 +14,7 @@ namespace sltbench {
 		template<typename C> static no  test(...);\
 	public:\
 		static constexpr bool value = sizeof(test<T>(0)) == sizeof(yes);\
-	};
+	}
 
 SLTBENCH_PRIVATE_DEFINE_CHECKER_HAS_INNER_TYPEDEF(ArgType);
 SLTBENCH_PRIVATE_DEFINE_CHECKER_HAS_INNER_TYPEDEF(Type);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,12 @@ set_target_properties(sltbench PROPERTIES
 	CXX_STANDARD_REQUIRED YES
 	CXX_EXTENSIONS NO)
 
+if (MSVC)
+	target_compile_options (sltbench PRIVATE /Wall /WX /sdl)
+else ()
+	target_compile_options (sltbench PRIVATE -Wall -Wextra -Werror -Wpedantic)
+endif ()
+
 target_include_directories(sltbench PUBLIC
 	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,7 +74,7 @@ set_target_properties(sltbench PROPERTIES
 	CXX_EXTENSIONS NO)
 
 if (MSVC)
-	target_compile_options (sltbench PRIVATE /Wall /WX /sdl)
+	target_compile_options (sltbench PRIVATE /W4 /WX /sdl)
 else ()
 	target_compile_options (sltbench PRIVATE -Wall -Wextra -Werror -Wpedantic)
 endif ()

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -8,7 +8,7 @@
 namespace sltbench {
 
 Config::Config()
-	: is_measure_required_pred_([](std::chrono::nanoseconds ns) { return true; })
+	: is_measure_required_pred_([](std::chrono::nanoseconds) { return true; })
 {
 	measure_conf_.precision_percents = 5;
 	measure_conf_.max_execution_time = std::chrono::minutes(1);

--- a/src/MeasureAlgo.cpp
+++ b/src/MeasureAlgo.cpp
@@ -35,8 +35,8 @@ namespace sltbench {
 MeasureAlgo::MeasureAlgo(Conf conf) noexcept
 	: conf_(std::move(conf))
 	, required_spot_size_(0)
-	, result_(0)
 	, accumulated_execution_time_(nanoseconds::zero())
+	, result_(0)
 {
 }
 


### PR DESCRIPTION
This solves issue #64.

Stricter compilation flags are added  in the CMakeLists.txt file for both, Windows and Linux.
Errors that would break compilation under Linux are solved.