### PR TITLE
[src] Fix gcc 11 build

### DIFF
--- a/src/MAResultsContainer.h
+++ b/src/MAResultsContainer.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <cstdint>
+#include <cstddef>
 
 
 namespace sltbench {


### PR DESCRIPTION
fix build on Ubuntu 22.04 
```
In file included from /ws/build-22/sltbench/src/MAResultsContainer.cpp:1:
/ws/build-22/sltbench/src/MAResultsContainer.h:24:17: error: 'size_t' has not been declared
   24 |                 size_t spot_size,
      |                 ^~~~~~
/ws/build-22/sltbench/src/MAResultsContainer.h:29:28: error: 'size_t' was not declared in this scope; did you mean 'std::size_t'?
   29 |         std::map<uint64_t, size_t> ns_to_count_;
      |                            ^~~~~~
      |                            std::size_t
In file included from /usr/include/c++/11/bits/stl_algobase.h:59,
                 from /usr/include/c++/11/bits/stl_tree.h:63,
                 from /usr/include/c++/11/map:60,
                 from /ws/build-22/sltbench/src/MAResultsContainer.h:3,
                 from /ws/build-22/sltbench/src/MAResultsContainer.cpp:1:
/usr/include/x86_64-linux-gnu/c++/11/bits/c++config.h:280:33: note: 'std::size_t' declared here
  280 |   typedef __SIZE_TYPE__         size_t;
      |                                 ^~~~~~
In file included from /ws/build-22/sltbench/src/MAResultsContainer.cpp:1:
/ws/build-22/sltbench/src/MAResultsContainer.h:29:34: error: template argument 2 is invalid
   29 |         std::map<uint64_t, size_t> ns_to_count_;
      |                                  ^
/ws/build-22/sltbench/src/MAResultsContainer.h:29:34: error: template argument 4 is invalid
/ws/build-22/sltbench/src/MAResultsContainer.h:32:9: error: 'size_t' does not name a type
   32 |         size_t total_count_ = 0;
      |         ^~~~~~
/ws/build-22/sltbench/src/MAResultsContainer.h:5:1: note: 'size_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
    4 | #include <cstdint>
  +++ |+#include <cstddef>
    5 | #include <cstdint>
/ws/build-22/sltbench/src/MAResultsContainer.cpp: In member function 'void sltbench::MAResultsContainer::Add(uint64_t)':
/ws/build-22/sltbench/src/MAResultsContainer.cpp:14:11: error: 'total_count_' was not declared in this scope
   14 |         ++total_count_;
      |           ^~~~~~~~~~~~
/ws/build-22/sltbench/src/MAResultsContainer.cpp:18:32: error: request for member 'lower_bound' in '((sltbench::MAResultsContainer*)this)->sltbench::MAResultsContainer::ns_to_count_', which is of non-class type 'int'
   18 |         auto it = ns_to_count_.lower_bound(lower_value);
      |                                ^~~~~~~~~~~
/ws/build-22/sltbench/src/MAResultsContainer.cpp:19:32: error: request for member 'end' in '((sltbench::MAResultsContainer*)this)->sltbench::MAResultsContainer::ns_to_count_', which is of non-class type 'int'
   19 |         if (it == ns_to_count_.end() || // all values are very small
      |                                ^~~
/ws/build-22/sltbench/src/MAResultsContainer.cpp:22:29: error: invalid types 'int[const uint64_t {aka const long unsigned int}]' for array subscript
   22 |                 ns_to_count_[time_ns] = 1;
      |                             ^
/ws/build-22/sltbench/src/MAResultsContainer.cpp: At global scope:
/ws/build-22/sltbench/src/MAResultsContainer.cpp:32:10: error: no declaration matches 'uint64_t sltbench::MAResultsContainer::GetMinSpotValue(size_t, uint8_t) const'
   32 | uint64_t MAResultsContainer::GetMinSpotValue(
      |          ^~~~~~~~~~~~~~~~~~
In file included from /ws/build-22/sltbench/src/MAResultsContainer.cpp:1:
/ws/build-22/sltbench/src/MAResultsContainer.h:23:18: note: candidate is: 'uint64_t sltbench::MAResultsContainer::GetMinSpotValue(int, uint8_t) const'
   23 |         uint64_t GetMinSpotValue(
      |                  ^~~~~~~~~~~~~~~
/ws/build-22/sltbench/src/MAResultsContainer.h:9:7: note: 'class sltbench::MAResultsContainer' defined here
    9 | class MAResultsContainer
      |       ^~~~~~~~~~~~~~~~~~
/ws/build-22/sltbench/src/MAResultsContainer.cpp: In member function 'uint64_t sltbench::MAResultsContainer::GetBest() const':
/ws/build-22/sltbench/src/MAResultsContainer.cpp:69:27: error: request for member 'empty' in '((const sltbench::MAResultsContainer*)this)->sltbench::MAResultsContainer::ns_to_count_', which is of non-class type 'const int'
   69 |         if (!ns_to_count_.empty())
      |                           ^~~~~
/ws/build-22/sltbench/src/MAResultsContainer.cpp:70:37: error: request for member 'begin' in '((const sltbench::MAResultsContainer*)this)->sltbench::MAResultsContainer::ns_to_count_', which is of non-class type 'const int'
   70 |                 return ns_to_count_.begin()->first;
      |                                     ^~~~~
make[2]: *** [src/CMakeFiles/sltbench.dir/build.make:174: src/CMakeFiles/sltbench.dir/MAResultsContainer.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:98: src/CMakeFiles/sltbench.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```